### PR TITLE
Add basic PHPUnit setup and CSRF protections

### DIFF
--- a/pages/login.php
+++ b/pages/login.php
@@ -21,10 +21,11 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         $user = mysqli_fetch_assoc($result);
         
         // Verifikasi password tanpa hashing
-        if ($password === $user['password']) {  
+        if ($password === $user['password']) {
             $_SESSION['user_id'] = $user['id'];
             $_SESSION['username'] = $user['username'];
-          
+            // Generate CSRF token setelah login berhasil
+            $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 
             // Redirect ke halaman admin yang benar
             header("Location: index.php?page=admin");

--- a/pages/update_solusi.php
+++ b/pages/update_solusi.php
@@ -1,5 +1,11 @@
 <?php
+session_start();
 include 'koneksi.php';
+
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== ($_SESSION['csrf_token'] ?? '')) {
+    echo json_encode(["success" => false, "error" => "Invalid CSRF token"]);
+    exit;
+}
 
 if (isset($_POST['id']) && isset($_POST['solusi'])) {
     $id = mysqli_real_escape_string($conn, $_POST['id']);

--- a/pages/update_status.php
+++ b/pages/update_status.php
@@ -1,7 +1,12 @@
 <?php
+session_start();
 include 'koneksi.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== ($_SESSION['csrf_token'] ?? '')) {
+        echo json_encode(["success" => false, "error" => "Invalid CSRF token"]);
+        exit;
+    }
     if (isset($_POST['id']) && isset($_POST['status'])) {
         $id = mysqli_real_escape_string($conn, $_POST['id']);
         $status = mysqli_real_escape_string($conn, $_POST['status']);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true">
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/CsrfTest.php
+++ b/tests/CsrfTest.php
@@ -1,0 +1,17 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class CsrfTest extends TestCase
+{
+    public function testUpdateStatusRequiresCsrfToken()
+    {
+        $content = file_get_contents(__DIR__ . '/../pages/update_status.php');
+        $this->assertStringContainsString('Invalid CSRF token', $content);
+    }
+
+    public function testUpdateSolusiRequiresCsrfToken()
+    {
+        $content = file_get_contents(__DIR__ . '/../pages/update_solusi.php');
+        $this->assertStringContainsString('Invalid CSRF token', $content);
+    }
+}

--- a/tests/LoginTest.php
+++ b/tests/LoginTest.php
@@ -1,0 +1,26 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class LoginTest extends TestCase
+{
+    private string $loginFile;
+
+    protected function setUp(): void
+    {
+        $this->loginFile = file_get_contents(__DIR__ . '/../pages/login.php');
+    }
+
+    public function testSuccessfulLogin()
+    {
+        // Check that session variables are set on successful login
+        $this->assertStringContainsString('$_SESSION[\'user_id\']', $this->loginFile);
+        $this->assertStringContainsString('$_SESSION[\'username\']', $this->loginFile);
+        $this->assertStringContainsString('$_SESSION[\'csrf_token\']', $this->loginFile);
+    }
+
+    public function testFailedLoginWithWrongPassword()
+    {
+        // Ensure error message for wrong password exists
+        $this->assertStringContainsString('Password salah', $this->loginFile);
+    }
+}


### PR DESCRIPTION
## Summary
- generate CSRF token on login
- enforce CSRF token in `update_status.php` and `update_solusi.php`
- add PHPUnit configuration and basic tests

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684390c69ef48331a740543465c9253b