### PR TITLE
Remove commented optional login case

### DIFF
--- a/index.php
+++ b/index.php
@@ -46,8 +46,6 @@ switch ($page) {
     include 'pages/update_status.php';
     break;
 
-    // (Opsional) case 'login': include 'pages/login.php'; break;
-
   default:
     // Halaman tidak dikenali => 404
     echo "<h2>Halaman tidak ditemukan!</h2>";


### PR DESCRIPTION
## Summary
- clean up router by removing the commented optional login line

## Testing
- `php -l index.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684390c14d8c8331ada1cd690b3349e4