### PR TITLE
Add CSRF verification and start sessions

### DIFF
--- a/adminbak.php
+++ b/adminbak.php
@@ -1,6 +1,6 @@
 <?php
-session_start();
 include 'koneksi.php';
+session_start();
 
 // Periksa apakah pengguna sudah login
 if (!isset($_SESSION['user_id'])) {

--- a/pages/add.php
+++ b/pages/add.php
@@ -1,8 +1,14 @@
 <?php
 // pages/addlpr.php
 include 'koneksi.php';
+session_start();
 
 if (isset($_POST['submit'])) {
+    if (!isset($_SESSION['csrf_token']) || !isset($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        header('Content-Type: application/json');
+        echo json_encode(["success" => false, "error" => "Invalid CSRF token"]);
+        exit;
+    }
     // Ambil data form
     $nama      = $_POST['nama'];
     $nim       = $_POST['nim'];

--- a/pages/admin.php
+++ b/pages/admin.php
@@ -1,7 +1,6 @@
 <?php
-session_start();
-
 include 'koneksi.php';
+session_start();
 
 // Periksa apakah pengguna sudah login
 if (!isset($_SESSION['user_id'])) {

--- a/pages/get_laporan.php
+++ b/pages/get_laporan.php
@@ -1,5 +1,6 @@
 <?php
 include 'koneksi.php';
+session_start();
 
 header('Content-Type: application/json');
 

--- a/pages/home.php
+++ b/pages/home.php
@@ -1,6 +1,7 @@
 <?php
 // pages/home.php
 include 'koneksi.php';
+session_start();
 
 // Jika ada parameter ?status, kita tampilkan SweetAlert
 if (isset($_GET['status'])) {

--- a/pages/login.php
+++ b/pages/login.php
@@ -1,6 +1,6 @@
 <?php
-session_start();
 include 'koneksi.php';
+session_start();
 
 // Jika user sudah login, arahkan ke halaman admin
 if (isset($_SESSION['user_id'])) {

--- a/pages/update_solusi.php
+++ b/pages/update_solusi.php
@@ -1,7 +1,12 @@
 <?php
 include 'koneksi.php';
+session_start();
 
 if (isset($_POST['id']) && isset($_POST['solusi'])) {
+    if (!isset($_SESSION['csrf_token']) || !isset($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        echo json_encode(["success" => false, "error" => "Invalid CSRF token"]);
+        exit;
+    }
     $id = mysqli_real_escape_string($conn, $_POST['id']);
     $solusi = mysqli_real_escape_string($conn, $_POST['solusi']);
 

--- a/pages/update_status.php
+++ b/pages/update_status.php
@@ -1,7 +1,12 @@
 <?php
 include 'koneksi.php';
+session_start();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!isset($_SESSION['csrf_token']) || !isset($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        echo json_encode(["success" => false, "error" => "Invalid CSRF token"]);
+        exit;
+    }
     if (isset($_POST['id']) && isset($_POST['status'])) {
         $id = mysqli_real_escape_string($conn, $_POST['id']);
         $status = mysqli_real_escape_string($conn, $_POST['status']);


### PR DESCRIPTION
## Summary
- initialize sessions after including `koneksi.php`
- guard POST actions with CSRF token validation

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684390ba99bc83319ad6d318415541cc