### PR TITLE
Implement CSRF helper and PHPUnit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,12 @@ File `koneksi.php` berisi contoh kredensial bawaan. Pastikan mengganti
 kredensial tersebut pada lingkungan produksi dan lindungi file dari akses
 publik.
 
+## Pengujian
+
+Proyek ini menyiapkan kerangka `PHPUnit` dasar. Jalankan perintah berikut setelah
+melakukan `composer install` untuk menjalankan test:
+
+```bash
+vendor/bin/phpunit
+```
+

--- a/adminbak.php
+++ b/adminbak.php
@@ -1,6 +1,8 @@
 <?php
 include 'koneksi.php';
 session_start();
+require_once 'csrf.php';
+ensure_csrf_token();
 
 // Periksa apakah pengguna sudah login
 if (!isset($_SESSION['user_id'])) {

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^9"
+    },
+    "autoload": {
+        "files": ["csrf.php"]
+    }
+}

--- a/csrf.php
+++ b/csrf.php
@@ -1,0 +1,11 @@
+<?php
+function ensure_csrf_token() {
+    if (!isset($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function verify_csrf_token($token) {
+    return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
+}

--- a/index.php
+++ b/index.php
@@ -3,6 +3,8 @@
 
 // Mulai session di awal sebelum include file lain
 session_start();
+require_once 'csrf.php';
+ensure_csrf_token();
 
 
 include 'layout.php';

--- a/pages/add.php
+++ b/pages/add.php
@@ -2,9 +2,11 @@
 // pages/addlpr.php
 include 'koneksi.php';
 session_start();
+require_once 'csrf.php';
+ensure_csrf_token();
 
 if (isset($_POST['submit'])) {
-    if (!isset($_SESSION['csrf_token']) || !isset($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+    if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
         header('Content-Type: application/json');
         echo json_encode(["success" => false, "error" => "Invalid CSRF token"]);
         exit;

--- a/pages/admin.php
+++ b/pages/admin.php
@@ -1,6 +1,8 @@
 <?php
 include 'koneksi.php';
 session_start();
+require_once 'csrf.php';
+ensure_csrf_token();
 
 // Periksa apakah pengguna sudah login
 if (!isset($_SESSION['user_id'])) {

--- a/pages/daftar.php
+++ b/pages/daftar.php
@@ -1,10 +1,14 @@
 <?php
 // pages/daftar.php
+session_start();
+require_once 'csrf.php';
+ensure_csrf_token();
 ?>
 <h1>Buat Laporan</h1>
 <p>Isi form berikut untuk melaporkan permasalahan. Segala informasi pribadi seperti nama, NIM, dan kelas akan dirahasiakan.</p>
 
 <form action="index.php?page=addlpr" method="POST" enctype="multipart/form-data">
+  <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($_SESSION['csrf_token']) ?>">
   <div class="form-group">
     <label for="nama">Nama</label>
     <input 

--- a/pages/get_laporan.php
+++ b/pages/get_laporan.php
@@ -1,6 +1,8 @@
 <?php
 include 'koneksi.php';
 session_start();
+require_once 'csrf.php';
+ensure_csrf_token();
 
 header('Content-Type: application/json');
 

--- a/pages/home.php
+++ b/pages/home.php
@@ -2,6 +2,8 @@
 // pages/home.php
 include 'koneksi.php';
 session_start();
+require_once 'csrf.php';
+ensure_csrf_token();
 
 // Jika ada parameter ?status, kita tampilkan SweetAlert
 if (isset($_GET['status'])) {

--- a/pages/login.php
+++ b/pages/login.php
@@ -1,6 +1,8 @@
 <?php
 include 'koneksi.php';
 session_start();
+require_once 'csrf.php';
+ensure_csrf_token();
 
 // Jika user sudah login, arahkan ke halaman admin
 if (isset($_SESSION['user_id'])) {
@@ -10,8 +12,11 @@ if (isset($_SESSION['user_id'])) {
 
 // Proses login
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
-    $username = mysqli_real_escape_string($conn, $_POST['username']);
-    $password = $_POST['password']; // Password dalam format plain text
+    if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+        $error = "Invalid CSRF token";
+    } else {
+        $username = mysqli_real_escape_string($conn, $_POST['username']);
+        $password = $_POST['password']; // Password dalam format plain text
 
     // Query untuk mendapatkan data user
     $query = "SELECT * FROM users WHERE username = '$username' LIMIT 1";
@@ -35,6 +40,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     } else {
         $error = "Username tidak ditemukan!";
     }
+    }
 }
 
 
@@ -55,6 +61,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                         <?php endif; ?>
 
                         <form method="POST" action="">
+                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($_SESSION['csrf_token']) ?>">
                             <div class="mb-3">
                                 <label for="username" class="form-label">Username</label>
                                 <input type="text" name="username" id="username" class="form-control" required>

--- a/pages/update_solusi.php
+++ b/pages/update_solusi.php
@@ -1,9 +1,11 @@
 <?php
 include 'koneksi.php';
 session_start();
+require_once 'csrf.php';
+ensure_csrf_token();
 
 if (isset($_POST['id']) && isset($_POST['solusi'])) {
-    if (!isset($_SESSION['csrf_token']) || !isset($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+    if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
         echo json_encode(["success" => false, "error" => "Invalid CSRF token"]);
         exit;
     }

--- a/pages/update_status.php
+++ b/pages/update_status.php
@@ -1,9 +1,11 @@
 <?php
 include 'koneksi.php';
 session_start();
+require_once 'csrf.php';
+ensure_csrf_token();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    if (!isset($_SESSION['csrf_token']) || !isset($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+    if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
         echo json_encode(["success" => false, "error" => "Invalid CSRF token"]);
         exit;
     }

--- a/tests/CsrfTest.php
+++ b/tests/CsrfTest.php
@@ -1,0 +1,22 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class CsrfTest extends TestCase
+{
+    public function testTokenGeneration()
+    {
+        \session_start();
+        unset($_SESSION['csrf_token']);
+        $token = ensure_csrf_token();
+        $this->assertNotEmpty($token);
+        $this->assertEquals($token, $_SESSION['csrf_token']);
+    }
+
+    public function testTokenVerification()
+    {
+        \session_start();
+        $token = ensure_csrf_token();
+        $this->assertTrue(verify_csrf_token($token));
+        $this->assertFalse(verify_csrf_token('invalid'));
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable CSRF helper
- protect forms with CSRF tokens
- set up Composer and PHPUnit
- document tests in README

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*
- `phpunit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843940d05748331a9d76f6e73bbf7c8